### PR TITLE
Allow passing additional arguments to make command in dkms-make.sh

### DIFF
--- a/dkms-make.sh
+++ b/dkms-make.sh
@@ -20,4 +20,4 @@ if [ "$sproc" -gt 1 ]; then
 fi
 
 kernelver=${kernelver:-$(uname -r)}
-make "-j$sproc" "KVER=$kernelver" "KSRC=/lib/modules/$kernelver/build" "KBUILD_MODPOST_WARN=1"
+make "-j$sproc" "KVER=$kernelver" "KSRC=/lib/modules/$kernelver/build" "KBUILD_MODPOST_WARN=1" "$@"


### PR DESCRIPTION
Running ./install-driver.sh produces the following [error log](https://gist.github.com/MikeGriniezakis/2810c6d0d176b45e1aa15e2dc189c67a). Allowing DKMS to pass parameters to the make command fixed the issue and allowed it to install correctly. It seems that dkms adds the parameter ```LLVM=1``` to the make command.

Tested on CachyOS, linux 7.0.8-1-cachyos, dkms-3.4.0