### PR TITLE
Fix Runtime PM usage count underflow

### DIFF
--- a/include/rtw_pwrctrl.h
+++ b/include/rtw_pwrctrl.h
@@ -47,8 +47,8 @@ struct pwrctrl_priv {
 	u8		bInSuspend;
 #ifdef CONFIG_BTC
 	u8		bAutoResume;
-	u8		autopm_cnt;
 #endif
+	u8		autopm_cnt;
 	u8		bSupportRemoteWakeup;
 	u8		wowlan_ap_mode;
 	u8		wowlan_mode;

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -790,9 +790,8 @@ _adapter *rtw_usb_primary_adapter_init(struct dvobj_priv *dvobj,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 33))
 	if (usb_autopm_get_interface(pusb_intf) < 0)
 		RTW_INFO("can't get autopm:\n");
-#endif
-#ifdef CONFIG_BTC
-	dvobj_to_pwrctl(dvobj)->autopm_cnt = 1;
+	else
+		dvobj_to_pwrctl(dvobj)->autopm_cnt = 1;
 #endif
 
 	/* get mac addr */
@@ -822,9 +821,7 @@ static void rtw_usb_primary_adapter_deinit(_adapter *padapter)
 {
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
-#ifdef CONFIG_BTC
 	if (1 == adapter_to_pwrctl(padapter)->autopm_cnt) {
-		struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 		struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 		PUSB_DATA usb_data = dvobj_to_usb(dvobj);
 
@@ -837,7 +834,6 @@ static void rtw_usb_primary_adapter_deinit(_adapter *padapter)
 #endif
 		adapter_to_pwrctl(padapter)->autopm_cnt--;
 	}
-#endif
 
 	rtw_free_drv_sw(padapter);
 


### PR DESCRIPTION
Same bug as the bu version you merged this morning (a16bf72e), same fix. Applies cleanly to cu with a 12-line offset because cu's source is a bit shorter. Tested on two RTL8852CU adapters here on kernel 7.0.5, no WARN on rmmod, no regression in the no-switch path.
