### PR TITLE
Drop overzealous WARN_ON on pre-init register access

### DIFF
--- a/phl/hal_g6/hal_api_mac.c
+++ b/phl/hal_g6/hal_api_mac.c
@@ -2387,7 +2387,6 @@ bool rtw_hal_mac_reg_chk(struct rtw_hal_com_t *hal_com, u32 addr)
 			rst = false;
 			PHL_ERR("%s failed - addr(0x%08x) is err code(%d)\n",
 				__func__, addr, mac_rst);
-			_os_warn_on(1);
 		}
 	}
 


### PR DESCRIPTION
Same as the bu warn-fix you merged today (824d227e). `mac_dbg_status_dump` runs DMAC/CMAC/BB register reads from `mac_hal_init`'s error path before those blocks are up. The check correctly returns false and `hal_io.c` handles it with a sentinel, but the WARN_ON fires for every read and you get dozens of stack traces per init cycle on top of the `PHL_ERR` line. Just drop the warn, the error path still logs fine.
