### PR TITLE
Change driver default to USB2

### DIFF
--- a/8852cu.conf
+++ b/8852cu.conf
@@ -20,7 +20,7 @@ options usb-storage quirks=0bda:1a2b:i
 # # to beginning of line to inactivate it and see AP mode line further
 # down:
 #
-options 8852cu rtw_switch_usb_mode=1
+options 8852cu rtw_switch_usb_mode=0
 #
 # Note: To activate USB3 mode, change `rtw_switch_usb_mode=0` above to
 # `rtw_switch_usb_mode=1`


### PR DESCRIPTION
Same flip you did on bu (22128a60). Keeping it as its own PR so the PM and WARN ones can land on their own if you want more time on the cu default question.

Didn't carry over the `rtw89_*` blacklists you added in the same bu commit. Figured that's a separate call for you to make on cu.
