### PR TITLE
Add opt-in 6 GHz (6E) AP mode via rtw_6g_ap module parameter

### DIFF
--- a/core/rtw_chplan.c
+++ b/core/rtw_chplan.c
@@ -4271,13 +4271,15 @@ static void rtw_rfctl_regd_req_sel_and_status_update(struct rf_ctl_t *rfctl)
 
 #ifdef CONFIG_AP_MODE
 #if CONFIG_AP_REGU_FORBID
+extern int rtw_6g_ap;
 bool rtw_rfctl_is_regu_forbid_bss(struct rf_ctl_t *rfctl, enum band_type band)
 {
 	if (!rtw_txpwr_hal_is_txpwr_limit_needed(rfctl_to_dvobj(rfctl)))
 		return false;
 
-	/* forbid before 6G AP regulatory ready */
-	return band == BAND_ON_6G;
+	/* 6G AP regulatory (AFC/power category) is unimplemented; only allow a
+	 * 6G BSS when explicitly opted in via rtw_6g_ap (LPI indoor regions). */
+	return band == BAND_ON_6G && !rtw_6g_ap;
 }
 #endif
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -11178,6 +11178,7 @@ static void rtw_cfg80211_init_vht_capab(_adapter *padapter,
 #endif /* defined(CONFIG_80211AC_VHT) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)) */
 
 #if defined(CONFIG_80211AX_HE) && (defined(CPTCFG_VERSION) || (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)))
+extern int rtw_6g_ap;
 static int rtw_cfg80211_init_he_capab(_adapter *padapter,
 	struct ieee80211_sband_iftype_data *sta_iface_data,
 	enum nl80211_iftype iftype, struct phy_cap_t *phy_cap,
@@ -11201,8 +11202,9 @@ static int rtw_cfg80211_init_he_capab(_adapter *padapter,
 		return _FAIL;
 
 #if CONFIG_IEEE80211_BAND_6GHZ
-	/* forbid before 6G AP regulatory ready */
-	if (rtw_txpwr_hal_is_txpwr_limit_needed(adapter_to_dvobj(padapter))
+	/* publish 6G AP HE caps only when 6G AP is opted in (see rtw_6g_ap) */
+	if (!rtw_6g_ap
+		&& rtw_txpwr_hal_is_txpwr_limit_needed(adapter_to_dvobj(padapter))
 		&& band == NL80211_BAND_6GHZ && iftype == NL80211_IFTYPE_AP)
 		return _FAIL;
 #endif

--- a/os_dep/linux/rtw_cfg.c
+++ b/os_dep/linux/rtw_cfg.c
@@ -298,6 +298,10 @@ MODULE_PARM_DESC(rtw_vht_rx_mcs_map, "VHT RX MCS map");
 #ifdef CONFIG_80211AX_HE
 int rtw_he_enable = 1; /* 0:disable, 1:enable, 2:force auto enable */
 module_param(rtw_he_enable, int, 0644);
+
+int rtw_6g_ap = 0; /* 0:disable, 1:enable 6GHz AP mode (LPI indoor only; no AFC) */
+module_param(rtw_6g_ap, int, 0644);
+MODULE_PARM_DESC(rtw_6g_ap, "Enable 6GHz AP mode (default 0). Only enable where LPI indoor 6GHz operation is permitted without AFC (e.g. GB/EU); AFC/power-category enforcement is not implemented.");
 #endif
 
 int rtw_lowrate_two_xmit = 1;/* Use 2 path Tx to transmit MCS0~7 and legacy mode */

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -529,6 +529,7 @@ static void rtw_regd_apply_dfs_flags(struct get_chplan_resp *chplan, bool rtnl_l
 		rtnl_unlock();
 }
 
+extern int rtw_6g_ap;
 static u8 wiphy_chan_get_rtw_ch_flags(struct ieee80211_channel *chan)
 {
 	u8 flags;
@@ -553,9 +554,13 @@ static u8 wiphy_chan_get_rtw_ch_flags(struct ieee80211_channel *chan)
 		flags |= RTW_CHF_NO_HT40L;
 	#endif
 	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 9, 0))
-	if (chan->flags & IEEE80211_CHAN_NO_80MHZ)
+	/* with 6G AP enabled, do not inherit the kernel regdb 6G width caps
+	 * (some regdomains cap 6G to 20MHz); permit wide 6G channels */
+	if (!(rtw_6g_ap && chan->band == NL80211_BAND_6GHZ)
+	    && (chan->flags & IEEE80211_CHAN_NO_80MHZ))
 		flags |= RTW_CHF_NO_80MHZ;
-	if (chan->flags & IEEE80211_CHAN_NO_160MHZ)
+	if (!(rtw_6g_ap && chan->band == NL80211_BAND_6GHZ)
+	    && (chan->flags & IEEE80211_CHAN_NO_160MHZ))
 		flags |= RTW_CHF_NO_160MHZ;
 	#endif
 


### PR DESCRIPTION
The driver hard-blocks 6 GHz AP operation in three places (all commented "forbid before 6G AP regulatory ready") because 6 GHz AP regulatory enforcement (AFC / power category) is unimplemented.

This gates those three guards behind a new module parameter rtw_6g_ap (default 0). With the default, behavior is unchanged. When set to 1:
  - allow starting a BSS on 6 GHz (rtw_rfctl_is_regu_forbid_bss)
  - publish HE AP-iftype capabilities on 6 GHz (rtw_cfg80211_init_he_capab)
  - do not inherit the kernel regdb 6 GHz width caps, so wide (80/160 MHz) 6 GHz channels are usable (wiphy_chan_get_rtw_ch_flags)

Intended only for regions where LPI indoor 6 GHz operation is permitted without AFC (e.g. GB/EU). AFC/power-category remains unimplemented, hence default-off.

Tested: BrosTrend AXE5400 (RTL8852CU, 0bda:c832), Raspberry Pi 4B, Debian 13 / kernel 6.12.75, hostapd v2.12, regdomain GB. With rtw_6g_ap=1: 6 GHz AP on ch37 up to 160 MHz, WPA3-SAE, verified with a Wi-Fi 6E client passing traffic. With default rtw_6g_ap=0: unchanged.