### PR TITLE
Support Linux 7.1 cfg80211 API changes

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1824,7 +1824,12 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_add_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || defined(CONFIG_ACK_5_15_LTS_KERNEL)
 	, int link_id
 #endif
@@ -1834,6 +1839,12 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	, const u8 *mac_addr, struct key_params *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	char *alg_name;
 	u32 param_len;
 	struct ieee_param *param = NULL;
@@ -1991,7 +2002,12 @@ addkey_end:
 
 }
 
-static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_get_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || defined(CONFIG_ACK_5_15_LTS_KERNEL)
 	, int link_id
 #endif
@@ -2002,6 +2018,12 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
 	, const u8 *mac_addr, void *cookie
 	, void (*callback)(void *cookie, struct key_params *))
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 #define GET_KEY_PARAM_FMT_S " keyid=%d"
 #define GET_KEY_PARAM_ARG_S , keyid
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
@@ -2192,7 +2214,12 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_del_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || defined(CONFIG_ACK_5_15_LTS_KERNEL)
 	, int link_id
 #endif
@@ -2202,6 +2229,12 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev
 	, u8 key_index, const u8 *mac_addr)
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
 
@@ -2277,12 +2310,23 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy, struct net_device *
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
-int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy, struct net_device *ndev
+int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)) || defined(CONFIG_ACK_5_15_LTS_KERNEL)
 	, int link_id
 #endif
 	, u8 key_index)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 #define SET_DEF_KEY_PARAM_FMT " key_index=%d"
 #define SET_DEF_KEY_PARAM_ARG , key_index
 
@@ -2534,7 +2578,11 @@ static void sta_set_rate_info(_adapter *adapter, struct rate_info *rinfo,
 }
 
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
 	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -2542,6 +2590,12 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 #endif
 	struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	int ret = 0;
 	u8 bw, sgi;
 	u16 rtw_rate_idx;
@@ -3603,6 +3657,15 @@ bypass_p2p_chk:
 
 check_need_indicate_scan_done:
 	if (_TRUE == need_indicate_scan_done) {
+#if (KERNEL_VERSION(7, 1, 0) <= LINUX_VERSION_CODE)
+		/*
+		 * cfg80211 registers an internal split-scan request only after
+		 * the driver's scan callback returns. Completing a denied scan
+		 * synchronously therefore trips cfg80211's request validation.
+		 */
+		ret = -EBUSY;
+		goto exit;
+#else
 #if (KERNEL_VERSION(4, 8, 0) <= LINUX_VERSION_CODE)
 		struct cfg80211_scan_info info;
 
@@ -3617,6 +3680,7 @@ check_need_indicate_scan_done:
 		cfg80211_scan_done(request, &info);
 #else
 		cfg80211_scan_done(request, 0);
+#endif
 #endif
 	}
 
@@ -4930,7 +4994,11 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+		cfg80211_new_sta(ndev_to_wdev(ndev), get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+		#else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+		#endif
 	}
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->chandef.chan;
@@ -4980,7 +5048,11 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	cfg80211_del_sta(ndev_to_wdev(ndev), da, GFP_ATOMIC);
+	#else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
+	#endif
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = padapter_link->mlmeext.chandef.chan;
 	band = padapter_link->mlmeext.chandef.chan;
@@ -6122,7 +6194,12 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
-static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_add_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -6130,6 +6207,12 @@ static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	struct station_parameters *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 #if defined(CONFIG_TDLS) || defined(CONFIG_RTW_MESH)
@@ -6276,7 +6359,11 @@ release_plink_ctl:
 
 			/* indicate new sta */
 			_rtw_memset(&sinfo, 0, sizeof(sinfo));
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+			cfg80211_new_sta(ndev_to_wdev(ndev), mac, &sinfo, GFP_ATOMIC);
+			#else
 			cfg80211_new_sta(ndev, mac, &sinfo, GFP_ATOMIC);
+			#endif
 		}
 		goto exit;
 	}
@@ -6319,7 +6406,12 @@ exit:
 	return ret;
 }
 
-static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
@@ -6329,6 +6421,12 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 )
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	int ret = 0;
 	_list	*phead, *plist;
 	u8 updated = _FALSE;
@@ -6479,7 +6577,11 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 }
 
 static int cfg80211_rtw_change_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
 	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -6487,6 +6589,12 @@ static int cfg80211_rtw_change_station(struct wiphy *wiphy,
 #endif
 	struct station_parameters *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 	int ret = 0;
 
@@ -6546,9 +6654,20 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
-static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_dump_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 		int idx, u8 *mac, struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
+#endif
 #define DBG_DUMP_STATION 0
 
 	int ret = 0;


### PR DESCRIPTION
## Description

Linux 7.1 changed several cfg80211 operations and station notification APIs to use struct wireless_dev * instead of struct net_device *. The previous callback signatures compiled because incompatible-pointer warnings were suppressed, but cfg80211 passed a wireless_dev at runtime. Treating it as a net_device caused a kernel page fault during WPA key installation, crashing wpa_supplicant and leaving the system in a degraded state.

### Changes

- Add Linux 7.1-compatible signatures for these cfg80211 callbacks:
  - add_key
  - get_key
  - del_key
  - set_default_mgmt_key
  - add_station
  - del_station
  - change_station
  - get_station
  - dump_station

- Convert struct wireless_dev * to struct net_device * internally using wdev_to_ndev().
- Return -EINVAL when a callback has no associated network device.
- Pass struct wireless_dev * to Linux 7.1 versions of:
  - cfg80211_new_sta()
  - cfg80211_del_sta()

- Avoid synchronously calling cfg80211_scan_done() for denied scans on Linux 7.1. Split-scan requests are now registered after the driver callback returns, so denied scans return -EBUSY instead.

- Keep all previous code paths behind kernel-version guards so older kernels retain their existing APIs and behavior.

## Root cause

The driver’s Makefile suppresses incompatible-pointer-type warnings. Consequently, the Linux 7.1 callback signature mismatches did not fail the build and instead became runtime type confusion.

The failure occurred during the WPA four-way handshake in:

cfg80211_rtw_add_key

The invalid net_device interpretation caused a kernel page fault, terminated wpa_supplicant, and left IRQs disabled in the affected process context.

## Validation

Successfully built against:

- Linux 7.0.13
- Linux 7.1.3
- Linux 7.1.4

Runtime validation on Linux 7.1.4 confirmed:

- The adapter associates successfully.
- WPA key negotiation completes.
- Pairwise, group, and management keys are installed.
- NetworkManager activates the connection and obtains a DHCP address.
- The original cfg80211_rtw_add_key() page fault no longer occurs.

Linux 7.0.13 driver also worked as expected.