### PR TITLE
Build on kernel 7.2 and 7.3

### DIFF
--- a/core/rtw_smeofld.c
+++ b/core/rtw_smeofld.c
@@ -21,7 +21,11 @@
 int cfg80211_rtw_probe_client(struct wiphy *wiphy,
 			      struct net_device *ndev,
 			      const u8 *peer,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+			      u64 cookie)
+#else
 			      u64 *cookie)
+#endif
 {
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 	return 0;

--- a/include/rtw_smeofld.h
+++ b/include/rtw_smeofld.h
@@ -54,7 +54,11 @@ struct rtw_sme_auth_data {
 int cfg80211_rtw_probe_client(struct wiphy *wiphy,
 			      struct net_device *ndev,
 			      const u8 *peer,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+			      u64 cookie);
+#else
 			      u64 *cookie);
+#endif
 
 int rtw_sme_send_auth_challenge(_adapter *padapter, u8 *frame,
 				size_t frame_len,

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1941,7 +1941,11 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy,
 		goto addkey_end;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#else
 	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#endif
 
 
 	if (!mac_addr || is_broadcast_ether_addr(mac_addr)
@@ -5320,7 +5324,11 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	}
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(mon_ndev->name, name, IFNAMSIZ);
+#else
 	strncpy(mon_ndev->name, name, IFNAMSIZ);
+#endif
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4, 11, 8))
 	mon_ndev->priv_destructor = rtw_ndev_destructor;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -8454,8 +8454,15 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
 	enum nl80211_channel_type channel_type,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	unsigned int duration, u64 cookie_in)
+#else
 	unsigned int duration, u64 *cookie)
+#endif
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	u64 *cookie = &cookie_in;
+#endif
 	s32 err = 0;
 	u8 remain_ch = (u8) rtw_freq2ch(channel->center_freq);
 	enum band_type ro_band = nl80211_band_to_rtw_band(channel->band);
@@ -8523,7 +8530,10 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 		}
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+#else
 	*cookie = ATOMIC_INC_RETURN(&pcfg80211_rochinfo->ro_ch_cookie_gen);
+#endif
 
 	RTW_INFO(FUNC_ADPT_FMT"%s ch:%u duration:%d, cookie:0x%llx\n"
 		, FUNC_ADPT_ARG(padapter), wdev == wiphy_to_pd_wdev(wiphy) ? " PD" : ""
@@ -8576,8 +8586,15 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
 	enum nl80211_channel_type channel_type,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	unsigned int duration, u64 cookie_in)
+#else
 	unsigned int duration, u64 *cookie)
+#endif
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	u64 *cookie = &cookie_in;
+#endif
 	s32 err = 0;
 	u8 remain_ch = (u8) rtw_freq2ch(channel->center_freq);
 	_adapter *padapter = NULL;
@@ -8618,7 +8635,10 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 	is_p2p_find = (duration < (pwdinfo->ext_listen_interval)) ? _TRUE : _FALSE;
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+#else
 	*cookie = ATOMIC_INC_RETURN(&pcfg80211_wdinfo->ro_ch_cookie_gen);
+#endif
 
 	RTW_INFO(FUNC_ADPT_FMT"%s ch:%u duration:%d, cookie:0x%llx\n"
 		, FUNC_ADPT_ARG(padapter), wdev == wiphy_to_pd_wdev(wiphy) ? " PD" : ""
@@ -9065,7 +9085,11 @@ static int cfg80211_rtw_mgmt_tx(struct wiphy *wiphy,
 #else
 	struct cfg80211_mgmt_tx_params *params,
 #endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	u64 cookie_in)
+#else
 	u64 *cookie)
+#endif
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)) || defined(COMPAT_KERNEL_RELEASE)
 	struct ieee80211_channel *chan = params->chan;
@@ -9075,6 +9099,9 @@ static int cfg80211_rtw_mgmt_tx(struct wiphy *wiphy,
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 2, 0))
 	bool no_cck = 0;
+#endif
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	u64 *cookie = &cookie_in;
 #endif
 	int ret = 0;
 	u8 tx_ret;
@@ -9144,7 +9171,10 @@ static int cfg80211_rtw_mgmt_tx(struct wiphy *wiphy,
 	pwdev_priv = adapter_wdev_data(padapter);
 
 	/* cookie generation */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+#else
 	*cookie = pwdev_priv->mgmt_tx_cookie++;
+#endif
 
 #ifdef CONFIG_DEBUG_CFG80211
 	RTW_INFO(FUNC_ADPT_FMT"%s len=%zu, ch=%d"
@@ -12315,7 +12345,11 @@ struct cfg80211_ops rtw_cfg80211_ops = {
 	 * hostap::nl80211_setup_ap would not call nl80211_mgmt_subscribe_ap()
 	 * (which SAE AP shall use).
 	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+	.probe_peer = cfg80211_rtw_probe_client,
+#else
 	.probe_client = cfg80211_rtw_probe_client,
+#endif
 #endif
 #endif /* CONFIG_CFG80211_SME_OFFLOAD */
 	/* .auth = cfg80211_rtw_auth, */

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -2976,7 +2976,11 @@ static int rtw_wx_set_enc_ext(struct net_device *dev,
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#else
 	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#endif
 
 	if (pext->ext_flags & IW_ENCODE_EXT_SET_TX_KEY)
 		param->u.crypt.set_tx = 1;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -299,7 +299,11 @@ int rtw_ndev_init(struct net_device *dev)
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d mac_addr="MAC_FMT"\n"
 		, FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1), MAC_ARG(dev->dev_addr));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(adapter->old_ifname, dev->name, IFNAMSIZ);
+#else
 	strncpy(adapter->old_ifname, dev->name, IFNAMSIZ);
+#endif
 	adapter->old_ifname[IFNAMSIZ - 1] = '\0';
 #ifdef CONFIG_ARCH_CORTINA
 	dev->priv_flags = IFF_DOMAIN_WLAN;

--- a/phl/pltfm_ops_linux.h
+++ b/phl/pltfm_ops_linux.h
@@ -54,7 +54,20 @@ static inline char *_os_strcpy(char *dest, const char *src)
 }
 static inline char *_os_strncpy(char *dest, const char *src, size_t n)
 {
-	return strncpy(dest, src, n);
+	size_t i;
+
+	/* strncpy() was removed from the kernel in 7.2. Callers here copy a
+	 * fixed number of bytes into the middle of a buffer and must not be
+	 * NUL terminated, so strscpy() is not a substitute. Keep the original
+	 * semantics: copy up to n, pad the remainder with NUL, no guarantee
+	 * of termination.
+	 */
+	for (i = 0; i < n && src[i] != '\0'; i++)
+		dest[i] = src[i];
+	for (; i < n; i++)
+		dest[i] = '\0';
+
+	return dest;
 }
 #if 1
 #define _os_strchr(s, c) strchr(s, c)


### PR DESCRIPTION
Stock does not build from kernel 7.2 onward. Two changes underneath it.

7.2 removed strncpy from the kernel. Five call sites here need replacing.
7.3 changed three cfg80211 callbacks. All three now take the cookie by value,
and one of the three is also renamed. The rename only compiles with SME offload
switched on.

**One of the five needs care.** The platform layer wraps strncpy, and its eight
callers copy fixed byte counts into the middle of buffers, one of them splicing
a postfix into a filename. None wants a terminator. The obvious modern
replacement adds one, compiles clean, and quietly corrupts the regulatory file
parser. The wrapper keeps its old behaviour instead, in a few lines of its own.
Checked against the C library across 45 cases, five sources by nine lengths,
with no differences, including the case where the source fills the buffer and
no terminator is written. The other four take strscpy or strscpy_pad, gated so
older kernels are untouched.

Almost all of the build failure is that one wrapper. It sits in a header that
304 translation units include, so a keep-going build reports the same message
307 times. Only three direct call sites fail on their own:

	os_dep/linux/ioctl_cfg80211.c:1944
	os_dep/linux/ioctl_linux.c:2979
	os_dep/linux/os_intfs.c:302

	kernel                       stock              patched
	7.2.3 released               fails, no module   clean, module built
	7.3-rc1                      fails, no module   clean, module built
	6.18.37                      clean              clean, module built

The SME offload build was measured on rtl8852bu, which carries that row. The
code changed here is identical.

On an RTL8852CU on 6.18.37, stock against patched on the same adapter,
asserted by permanent MAC:

	capability and regulatory dump   identical, 681 lines, 106 channels
	associated               WPA2-PSK CCMP, 5 GHz, -45 dBm
	DHCP                     lease taken, gateway answers
	iperf3, 12 s, 4 streams  276 Mbit/s, 395 MB

Six files, +72/-1. Not tested: roaming, 6 GHz, WPA3, or any sustained soak.
